### PR TITLE
新增可設定的番茄時鐘網頁

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,97 @@
+const modeLabel = document.getElementById('modeLabel');
+const timeDisplay = document.getElementById('timeDisplay');
+const statusText = document.getElementById('statusText');
+
+const startBtn = document.getElementById('startBtn');
+const pauseBtn = document.getElementById('pauseBtn');
+const resetBtn = document.getElementById('resetBtn');
+const applyBtn = document.getElementById('applyBtn');
+
+const workInput = document.getElementById('workInput');
+const breakInput = document.getElementById('breakInput');
+
+let workMinutes = 25;
+let breakMinutes = 5;
+let isWorkMode = true;
+let remainingSeconds = workMinutes * 60;
+let timerId = null;
+
+function formatTime(seconds) {
+  const mins = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const secs = (seconds % 60).toString().padStart(2, '0');
+  return `${mins}:${secs}`;
+}
+
+function render() {
+  modeLabel.textContent = isWorkMode ? '專注時間' : '休息時間';
+  timeDisplay.textContent = formatTime(remainingSeconds);
+}
+
+function syncButtons(isRunning) {
+  startBtn.disabled = isRunning;
+  pauseBtn.disabled = !isRunning;
+}
+
+function switchMode() {
+  isWorkMode = !isWorkMode;
+  remainingSeconds = (isWorkMode ? workMinutes : breakMinutes) * 60;
+  statusText.textContent = isWorkMode ? '休息結束，回到專注！' : '做得好，休息一下吧！';
+}
+
+function tick() {
+  if (remainingSeconds > 0) {
+    remainingSeconds -= 1;
+    render();
+    return;
+  }
+
+  switchMode();
+  render();
+}
+
+function startTimer() {
+  if (timerId) return;
+  timerId = window.setInterval(tick, 1000);
+  syncButtons(true);
+  statusText.textContent = '計時中...保持專注！';
+}
+
+function pauseTimer() {
+  if (!timerId) return;
+  clearInterval(timerId);
+  timerId = null;
+  syncButtons(false);
+  statusText.textContent = '已暫停。準備好再繼續！';
+}
+
+function resetTimer() {
+  pauseTimer();
+  isWorkMode = true;
+  remainingSeconds = workMinutes * 60;
+  render();
+  statusText.textContent = '已重設為專注時間。';
+}
+
+function applySettings() {
+  const nextWork = Number(workInput.value);
+  const nextBreak = Number(breakInput.value);
+
+  if (!Number.isInteger(nextWork) || !Number.isInteger(nextBreak) || nextWork <= 0 || nextBreak <= 0) {
+    statusText.textContent = '請輸入有效的分鐘數（正整數）。';
+    return;
+  }
+
+  workMinutes = nextWork;
+  breakMinutes = nextBreak;
+  resetTimer();
+  statusText.textContent = `已套用：專注 ${workMinutes} 分鐘、休息 ${breakMinutes} 分鐘。`;
+}
+
+startBtn.addEventListener('click', startTimer);
+pauseBtn.addEventListener('click', pauseTimer);
+resetBtn.addEventListener('click', resetTimer);
+applyBtn.addEventListener('click', applySettings);
+
+render();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>番茄時鐘</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <h1>🍅 番茄時鐘</h1>
+
+    <div class="timer-card">
+      <p id="modeLabel" class="mode">專注時間</p>
+      <p id="timeDisplay" class="time">25:00</p>
+      <div class="controls">
+        <button id="startBtn">開始</button>
+        <button id="pauseBtn" disabled>暫停</button>
+        <button id="resetBtn">重設</button>
+      </div>
+    </div>
+
+    <section class="settings">
+      <h2>設定（分鐘）</h2>
+      <label>
+        專注
+        <input id="workInput" type="number" min="1" max="120" value="25" />
+      </label>
+      <label>
+        休息
+        <input id="breakInput" type="number" min="1" max="60" value="5" />
+      </label>
+      <button id="applyBtn">套用設定</button>
+    </section>
+
+    <p id="statusText" class="status">準備開始今天的專注吧！</p>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,104 @@
+:root {
+  color-scheme: light;
+  font-family: "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #ffe1e1, #fff6d8);
+  color: #2d2d2d;
+}
+
+.app {
+  width: min(92vw, 420px);
+  background: #ffffffd9;
+  backdrop-filter: blur(5px);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 32px #d97f7f40;
+}
+
+h1,
+h2 {
+  margin: 0.2rem 0 1rem;
+  text-align: center;
+}
+
+.timer-card {
+  border: 1px solid #ffd8d8;
+  border-radius: 14px;
+  padding: 1rem;
+  text-align: center;
+  background: #fff;
+}
+
+.mode {
+  margin: 0;
+  color: #d24b4b;
+  font-weight: 700;
+}
+
+.time {
+  margin: 0.4rem 0 0.8rem;
+  font-size: 3.2rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.08em;
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+button {
+  border: 0;
+  background: #ff7a7a;
+  color: #fff;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.settings {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+input {
+  width: 74px;
+  border: 1px solid #ffd0d0;
+  border-radius: 8px;
+  padding: 0.35rem;
+}
+
+#applyBtn {
+  justify-self: center;
+}
+
+.status {
+  margin: 1rem 0 0;
+  text-align: center;
+  color: #7a4747;
+}


### PR DESCRIPTION
### Motivation
- 提供一個簡單可離線使用的番茄時鐘網頁，讓使用者能以直覺的 UI 開始/暫停/重設計時並自訂專注與休息時長。 

### Description
- 新增 `index.html`，建立倒數顯示、模式文字、控制按鈕與分鐘設定欄位的頁面結構。 
- 新增 `styles.css`，實作卡片式版面、按鈕與輸入框樣式並提供響應式寬度限制。 
- 新增 `app.js`，實作番茄時鐘核心邏輯，包括每秒倒數、開始/暫停/重設、專注/休息模式切換、按鈕狀態同步與輸入驗證與套用設定。 
- 該頁面為靜態資源，可透過任意靜態伺服器（例如 `python3 -m http.server`）提供給瀏覽器使用。 

### Testing
- 使用 `python3 -m http.server 4173` 啟動靜態頁面並成功回應（已啟動且頁面可存取）。 
- 使用 Playwright 自動化腳本開啟 `http://127.0.0.1:4173`、點擊 `#startBtn` 並截圖以確認畫面與計時流程可運作，腳本執行成功且產生截圖。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81a9cb12083208fa1524f9f6c553c)